### PR TITLE
Enhance documentation readability and appeal

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,26 +1,46 @@
 # What is Ops Catalog
-**Ops catalog is a modern collaborative catalog solution designed to collect
-and make software engineering system metadata available for consumer apps
-to facilitate various automation tasks empowering the DevOps folks to provide 
-Internal SaaS platforms.**
+
+Ops Catalog is a modern, collaborative solution for managing and utilizing software engineering metadata. It empowers DevOps teams to build internal SaaS platforms by making system information readily available for automation and consumer applications.
 
 An asset catalog that increases developer happiness by putting Developers and DevOps front and centre.
 
-- Specification based collaborative catalog solution that empowers DevOps teams to automate workflows, enhance visibility, and drive efficiency. 
+- Specification based collaborative catalog solution that empowers DevOps teams to automate workflows, enhance visibility, and drive efficiency.
 - Build your modern internal SaaS platform with an API-first, open-standard catalog designed for maximum flexibility and automation.
 - Discover, manage, and provision software assets with ease.  Empower your DevOps teams with federated data management, powerful APIs, and built-in gamification.
 
 ![Ops Catalog](./assets/images/ops-catalog-summary.svg)
 
-The key principles of Ops Catalog are the following:
+## Key Principles
 
-- <span class="highlight">Federated Data Mgmt </span> - everyone authors what they own
-- <span class="highlight">Api First</span> - access asset information via API or subscribe to events
-- <span class="highlight">Open Standard</span> - open standard and attributes for modern workflows
+!!! note "Federated Data Mgmt :material-account-group-outline:"
+    Everyone authors what they own. This distributed ownership model ensures data accuracy and accountability, as those closest to the systems are responsible for their information.
 
-Other benefits include:
+!!! note "API First :material-api:"
+    Access asset information via API or subscribe to events. An API-first approach enables seamless integration with existing tools and automated workflows, making the catalog a dynamic part of your infrastructure.
 
-- <span class="aside">Quick bootstrap</span> - Discovery modules available to take stock of your assets
-- <span class="aside">Fulfillment</span> - Fulfillment plugins help with provisioning assets
-- <span class="aside">Friendly Competition</span> - scorecard shows where you are
+!!! note "Open Standard :material-book-open-page-variant-outline:"
+    Utilizes open standards and attributes for modern workflows. This promotes interoperability and allows for a flexible, extensible system that can adapt to evolving needs.
+
+## Other Benefits
+
+!!! tip "Quick Bootstrap :material-rocket-launch-outline:"
+    Discovery modules available to take stock of your assets. Quickly populate your catalog by automatically discovering existing resources across your environments.
+
+!!! tip "Fulfillment :material-cogs:"
+    Fulfillment plugins help with provisioning assets. Integrate with automation tools to enable self-service provisioning directly from the catalog.
+
+!!! tip "Friendly Competition & Gamification :material-trophy-outline:"
+    Scorecards and gamification elements can show where teams or services are in terms of documentation completeness, adherence to standards, or other desirable metrics, encouraging improvement.
+
+## Dive Deeper
+
+Ready to learn more?
+
+[Get Started with Ops Catalog](quickstart.md){ .md-button .md-button--primary }
+
+Or explore specific areas:
+
+*   [Why Ops Catalog?](whyoca.md) - Understand the value proposition.
+*   [Explore Use Cases](usecases.md) - See how it can be applied.
+*   [Read the Specification](spec/structure.md) - Delve into the technical details.
 

--- a/docs/whatisit.md
+++ b/docs/whatisit.md
@@ -1,23 +1,42 @@
 # What is it?
-Inspired by the tale of <a href="https://en.wikipedia.org/wiki/Blind_men_and_an_elephant" target="_blank">"Blind men and the elephant"</a>, here is a collection of what Ops-Catalog has been understood by individuals in different context.
+
+Understanding a comprehensive system like Ops Catalog can be like the fable of the <a href="https://en.wikipedia.org/wiki/Blind_men_and_an_elephant" target="_blank">blind men and the elephant</a>. Different people grasp different aspects, and while no single perspective is entirely wrong, it's the synthesis of these views that reveals the whole picture. This page explores common perceptions...
 
 ![Elephant Tale](./assets/images/elephant.jpeg)
 
-<div>
-    <table>
-    <tr><th>Here are a few ways to understand what Ops-Catalog is</th></tr>
-    <tr><td>It is a <span class="primary">CMDB but for Developers</span></td></tr>
-    <tr><td>It is a <span class="danger">registry for microservices</span></td></tr> 
-    <tr><td>It is a <span class="primary">catalog API for Backstage</span></td></tr>  
-    <tr><td>It is a <span class="danger">place to store Deployment Config</span></td></tr> 
-    <tr><td>It is a place to <span class="danger">lookup ownership data</span></td></tr> 
-    <tr><td>It creates <span class="danger">git repository</span></td></tr>  
-    <tr><td>It is a tool to <span class="danger">manage database schemas</span></td></tr> 
-    <tr><td>It helps find <span class="danger">Kubernetes workloads</span></td></tr> 
-    <tr><td>Ah so it collects <span class="danger">AWS resources</span></td></tr>
-    <tr><td>So it can <span class="danger">provision Kafka topics?</span></td></tr>  
-    <tr><td>It is an API server <span class="danger">for listing resources I own</span></td></tr> 
-    <tr><td>It is an <span class="primary"> aggregator to view all resources of the company</span></td></tr>  
-    </table>
-</div>
+!!! success "CMDB for Developers"
+    It is a CMDB but for Developers. This highlights its role in providing a structured, queryable inventory of operational components, tailored to developer needs for understanding and interacting with the tech landscape.
+
+!!! warning "Partial View: Registry for Microservices"
+    While it can act as a registry for microservices by cataloging their metadata and endpoints, its scope is much broader, encompassing various types of resources, components, and their relationships.
+
+!!! success "Catalog API for Backstage"
+    It serves as an excellent backend or catalog API for developer portals like Backstage, providing the structured data needed to populate such UIs.
+
+!!! danger "Misconception: Place to Store Deployment Config"
+    It's not primarily a system for storing raw deployment configurations (like K8s YAMLs or Helm charts). While it might link to such configs or catalog their existence, its focus is on metadata and relationships, not direct config management.
+
+!!! warning "Partial View: Place to Lookup Ownership Data"
+    Yes, it's a great place to look up ownership data for services, resources, and components. This is a key feature, but not its sole purpose.
+
+!!! danger "Misconception: Creates Git Repositories"
+    Ops Catalog itself does not typically create git repositories. It catalogs metadata about various entities, which might include information *about* git repositories, but it's not a Git repository management tool.
+
+!!! danger "Misconception: Tool to Manage Database Schemas"
+    While it might store metadata *about* databases (e.g., type, location, owner), it is not designed to manage or enforce database schemas directly.
+
+!!! warning "Partial View: Helps Find Kubernetes Workloads"
+    It can definitely help find and understand Kubernetes workloads by cataloging their metadata, relationships, and ownership. However, it's not limited to K8s and can catalog a wide variety of other components.
+
+!!! warning "Partial View: Collects AWS Resources"
+    It can collect and catalog AWS resources (or GCP, Azure, etc.), providing a unified view. But it's platform-agnostic and designed to handle resources from any environment.
+
+!!! danger "Misconception: Can Provision Kafka Topics"
+    While Ops Catalog can trigger automated workflows (e.g., via fulfillment engines) that *could* lead to provisioning Kafka topics, the catalog itself is not the provisioning engine. It holds the 'what' and 'why', and can initiate the 'how'.
+
+!!! warning "Partial View: API Server for Listing Resources I Own"
+    It does provide an API to list resources you own, which is a valuable feature for visibility and management. But it also serves broader organizational needs for understanding the entire tech ecosystem.
+
+!!! tip "Aggregator to View All Resources of the Company"
+    This is a strong understanding. Ops Catalog can aggregate information from various sources and discovery mechanisms to provide a comprehensive, company-wide view of technological assets and their relationships.
 

--- a/docs/whyoca.md
+++ b/docs/whyoca.md
@@ -1,47 +1,94 @@
 # Why Ops Catalog
 
-<span class="highlight">Just as you wouldn't navigate a book without an index, you can't steer a sizable business effectively without an Ops Catalog.</span>
+> Just as you wouldn't navigate a book without an index, you can't steer a sizable business effectively without an Ops Catalog.
 
-### The Challenge: Scattered Knowledge and Manual Drudgery
+!!! warning "The Challenge: Scattered Knowledge and Manual Drudgery"
+    In many organizations, information about infrastructure, APIs, services, and ownership resides in disparate silos—spreadsheets, wikis, even tribal knowledge.  Developers waste countless hours searching for what they need, contacting other teams for basic information, and manually provisioning resources. These friction points create frustration, delays, and potential misconfigurations.
 
-In many organizations, information about infrastructure, APIs, services, and ownership resides in disparate silos—spreadsheets, wikis, even tribal knowledge.  Developers waste countless hours searching for what they need, contacting other teams for basic information, and manually provisioning resources. These friction points create frustration, delays, and potential misconfigurations.
+!!! example "Conceptual Illustration: The Old Way (Scattered Knowledge)"
+    ```mermaid
+    graph LR
+        A[Developers] --> B{Looking for Info}
+        B --> C[Spreadsheets]
+        B --> D[Wikis]
+        B --> E[Tribal Knowledge]
+        B --> F[Other Teams]
+        C --> G((Pain Point: Wasted Time & Errors))
+        D --> G
+        E --> G
+        F --> G
+    ```
 
-### The Ops Catalog Solution: A Central Source of Truth
+!!! success "The Ops Catalog Solution: A Central Source of Truth"
+    An Ops Catalog system establishes a centralized, API-driven repository of information about all the components that make up an organization's technology stack. Key features drive value:
 
-An Ops Catalog system establishes a centralized, API-driven repository of information about all the components that make up an organization's technology stack. Key features drive value:
+    - Automated Discovery :material-magnify:: Specialized modules continually discover and update information about infrastructure, APIs, microservices, databases—all the building blocks developers rely on.
+    - Standardized Specification :material-format-list-checks:: Data adheres to a clear format, making it easily understandable and usable, both by humans and machines.
+    - API-Driven :material-api:: The API unlocks automation, letting developers integrate Ops Catalog data and workflows into their existing tools and CI/CD pipelines.
+    - Automated Provisioning :material-cogs:: Actions are taken when new resource requests are added to the catalog which promotes a scalable approach to providing self-service capability without manual toil.
 
-- Automated Discovery: Specialized modules continually discover and update information about infrastructure, APIs, microservices, databases—all the building blocks developers rely on.
-- Standardized Specification: Data adheres to a clear format, making it easily understandable and usable, both by humans and machines.
-- API-Driven: The API unlocks automation, letting developers integrate Ops Catalog data and workflows into their existing tools and CI/CD pipelines
-The Transformation
-- Automated Provisioning: Actions are taken when new resource requests are added to the catalog which promotes a scalable approach to providing self-service capability without manual toil.
+!!! example "Conceptual Illustration: The Ops Catalog Way (Centralized Hub)"
+    ```mermaid
+    graph LR
+        subgraph Ops Catalog
+            direction LR
+            H[Central Repository & API]
+        end
+        A[Developers] --> H
+        I[Automation Tools] --> H
+        J[CI/CD Pipelines] --> H
+        K[Consumer Apps] --> H
+        H --> L((Benefit: Efficiency & Single Source of Truth))
+        H --> M((Benefit: Consistency & Automation))
+    ```
 
 ### Process
-- From Searching to Finding: Developers no longer spend hours hunting for obscure details. The Ops Catalog delivers accurate data in seconds.
-- Self-Service Empowerment: With ready access to resource descriptions and potential automation for provisioning, developers can independently experiment, test, and deploy new solutions.
-- Knowledge Sharing and Collaboration: The Ops Catalog encourages teams to document their components and ownership. This fosters transparency and cross-team understanding.
-- From Reactive to Proactive: Armed with detailed data and insights, teams can proactively address potential issues, optimize configurations, and streamline development processes.
-The Outcome
+
+!!! note "From Searching to Finding :material-lightbulb-on-outline:"
+    Developers no longer spend hours hunting for obscure details. The Ops Catalog delivers accurate data in seconds.
+
+!!! note "Self-Service Empowerment :material-account-check-outline:"
+    With ready access to resource descriptions and potential automation for provisioning, developers can independently experiment, test, and deploy new solutions.
+
+!!! note "Knowledge Sharing and Collaboration :material-account-group-outline:"
+    The Ops Catalog encourages teams to document their components and ownership. This fosters transparency and cross-team understanding.
+
+!!! note "From Reactive to Proactive :material-chart-line:"
+    Armed with detailed data and insights, teams can proactively address potential issues, optimize configurations, and streamline development processes.
 
 ### Value
 The Ops Catalog ecosystem delivers both developer satisfaction and broader team benefits:
 
-- Accelerated Development: Less time wasted on hunting information and manual tasks means faster time to market.
-- Improved Quality: Standardized data and potential automation reduce errors and inconsistencies.
-- Heightened Collaboration: The shared resource breaks down silos and encourages knowledge sharing.
-- Boosted Morale: Empowered developers focused on building, not bureaucracy, are happier developers.
+!!! success "Accelerated Development :material-rocket-launch-outline:"
+    Less time wasted on hunting information and manual tasks means faster time to market.
+
+!!! success "Improved Quality :material-check-decagram-outline:"
+    Standardized data and potential automation reduce errors and inconsistencies.
+
+!!! tip "Heightened Collaboration :material-handshake-outline:"
+    The shared resource breaks down silos and encourages knowledge sharing.
+
+!!! tip "Boosted Morale :material-emoticon-happy-outline:"
+    Empowered developers focused on building, not bureaucracy, are happier developers.
 
 ### Takeaways
-🛠 <span class="highlight">Specification-based Collaboration:</span> Ops Catalog is not just a catalog; it's a dynamic collaborative solution! Empower your DevOps teams with the freedom to automate workflows, boost visibility, and supercharge efficiency.
 
-🌐 <span class="highlight">API-First, Open-Standard Catalog:</span> Building a modern internal SaaS platform? Ops Catalog is your go-to companion! With an API-first approach, it provides  flexibility and automation.
+!!! success "Specification-based Collaboration :material-tools:"
+    Ops Catalog is not just a catalog; it's a dynamic collaborative solution! Empower your DevOps teams with the freedom to automate workflows, boost visibility, and supercharge efficiency.
 
-🚀 <span class="highlight">Discover, Manage, and Provision with Ease:</span> Ops Catalog simplifies the complex. Effortlessly discover, manage, and provision software assets, putting you in control. No more headaches – just streamlined operations.
+!!! info "API-First, Open-Standard Catalog :material-web:"
+    Building a modern internal SaaS platform? Ops Catalog is your go-to companion! With an API-first approach, it provides  flexibility and automation.
 
-🤝 <span class="highlight">Federated Data Management and Powerful APIs:</span> We believe in the power of collaboration. Ops Catalog fosters federated data management and equips you with robust APIs, ensuring seamless connectivity and accessibility. Owners own and manage their data.
+!!! success "Discover, Manage, and Provision with Ease :material-auto-fix:"
+    Ops Catalog simplifies the complex. Effortlessly discover, manage, and provision software assets, putting you in control. No more headaches – just streamlined operations.
 
-✨ <span class="highlight">Tailored for Your Team:</span> Ops Catalog seamlessly integrates into your organizational setup, offering unparalleled flexibility. Run multiple Ops Catalogs without sacrificing visibility – each team can have its own, and a single catalog can effortlessly aggregate data from others. It's the agility your operations crave and the simplicity your teams deserve. Elevate your organizational dynamics with Ops Catalog – where adaptability meets simplicity! 🚀💻✨
+!!! tip "Federated Data Management and Powerful APIs :material-lan-connect:"
+    We believe in the power of collaboration. Ops Catalog fosters federated data management and equips you with robust APIs, ensuring seamless connectivity and accessibility. Owners own and manage their data.
 
-🎮 <span class="highlight">Built-in Gamification:</span> We're making work fun! Ops Catalog introduces gamification to keep your teams engaged and motivated. Watch productivity soar as tasks become challenges and milestones turn into victories.
+!!! info "Tailored for Your Team :material-account-cog-outline:"
+    Ops Catalog seamlessly integrates into your organizational setup, offering unparalleled flexibility. Run multiple Ops Catalogs without sacrificing visibility – each team can have its own, and a single catalog can effortlessly aggregate data from others. It's the agility your operations crave and the simplicity your teams deserve. Elevate your organizational dynamics with Ops Catalog – where adaptability meets simplicity! 🚀💻✨
+
+!!! tip "Built-in Gamification :material-gamepad-variant-outline:"
+    We're making work fun! Ops Catalog introduces gamification to keep your teams engaged and motivated. Watch productivity soar as tasks become challenges and milestones turn into victories.
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,9 +58,32 @@ markdown_extensions:
       pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.details # For collapsible admonition-style blocks
+  - pymdownx.betterem # For better emphasis handling
+  # - pymdownx.critic # Optional: for diff-like markup, include if desired for future use
+  - pymdownx.caret # For insert ^^ and delete ~~ syntax
+  # - pymdownx.keys # Optional: for keyboard symbols, include if relevant use cases exist
+  - pymdownx.mark # For highlighting text ==mark==
+  # - pymdownx.tilde # Optional: for subscript/superscript, include if relevant
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.tabbed:
+      alternate_style: true # Optional, for a different tab style
+  - pymdownx.tasklist:
+      custom_checkbox: true # For theme-styled checkboxes
+  - pymdownx.magiclink # To auto-link URLs and emails
   - attr_list
   - md_in_html
+  - toc:
+      permalink: true
+      # slugify: !!python/name:pymdownx.slugs.uslugify # Consider if needed
+  - admonition
 
 
 theme:
@@ -78,6 +101,14 @@ theme:
     - navigation.expand
     - navigation.path
     - toc.integrate
+    # New features to add
+    - navigation.top # Adds a "Back to top" button
+    - search.suggest # Enables search suggestions
+    - search.highlight # Highlights search terms on target pages
+    # - content.tabs.link # Add if pymdownx.tabbed is heavily used and cross-linking is desired
+    - content.code.annotate # For adding annotations to code blocks
+    - navigation.footer # Adds previous/next page links in the footer
+    # - navigation.tabs # Optional: if a tabbed top-level navigation is desired instead of sidebar sections for main nav. Evaluate impact.
   font:
     text: Arial
     code: Jetbrains Mono


### PR DESCRIPTION
This commit significantly revamps key documentation pages (`index.md`, `whyoca.md`, `whatisit.md`) to improve readability and visual appeal.

Key changes include:

- Updated `mkdocs.yml` to enable several Material for MkDocs features and PyMdownX extensions, such as:
    - Admonitions (`details`, `admonition`)
    - Content tabs (`pymdownx.tabbed`)
    - Mermaid diagrams (`pymdownx.superfences` with mermaid custom fence)
    - Emojis and icons (`pymdownx.emoji`)
    - Task lists (`pymdownx.tasklist`)
    - Enhanced code blocks (`content.code.annotate`)
    - Improved navigation (`navigation.top`, `navigation.footer`)
    - Better search (`search.suggest`, `search.highlight`)
- Replaced custom span-based styling (`.highlight`, `.aside`, `.primary`, `.danger`) with theme-native admonitions and icons for consistency.
- Restructured content in `whyoca.md`, `whatisit.md`, and `index.md` using admonitions to break up text, highlight key information, and guide you.
- Added Material Design icons to lists and admonition titles for better visual cues.
- Incorporated Mermaid diagram placeholders in `whyoca.md` to illustrate concepts.
- Clarified analogies and added more descriptive text in `whatisit.md`.
- Added a "Dive Deeper" call-to-action section in `index.md`.

These changes aim to make the documentation more engaging, easier to navigate, and more effective in conveying information about Ops Catalog.