### PR TITLE
Fix: Update GitHub Actions workflow and MkDocs config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,12 +42,16 @@ jobs:
           # echo "pymdownx.magiclink" >> requirements.txt
           # echo "pymdownx.superfences" >> requirements.txt
 
-      - name: Deploy with MkDocs Material
-        uses: peaceiris/actions-mkdocs-gh-pages@v4
+      - name: Build MkDocs site
+        run: |
+          pip install -r requirements.txt
+          mkdocs build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          requirements_file: requirements.txt
-          enable_pdf_export: true # Attempts to install WeasyPrint and its dependencies for mkdocs-with-pdf
+          publish_dir: ./site
           force_push: true # Equivalent to mkdocs gh-deploy --force
           # deploy_branch: gh-pages # Default is gh-pages
           # custom_domain: your.custom.domain # If you have one

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,8 +116,8 @@ theme:
 plugins:
   - render_swagger:
       allow_arbitrary_locations : true
-      javascript: ../../assets/js/swagger-ui-bundle.js
-      css: ../../assets/css/swagger-ui.css     
+      javascript: assets/js/swagger-ui-bundle.js
+      css: assets/css/swagger-ui.css     
   - with-pdf
 
       


### PR DESCRIPTION
- I corrected asset paths for `render_swagger` plugin in `mkdocs.yml`.
- I replaced archived `peaceiris/actions-mkdocs-gh-pages` GitHub Action with the maintained `peaceiris/actions-gh-pages@v4.0.0`.
- I added an explicit MkDocs build step in the workflow, including installation of dependencies from the generated `requirements.txt`.
- I set `publish_dir` to `./site` for the new deployment action.

These changes aim to resolve the GitHub Actions build failures caused by the outdated action and incorrect MkDocs asset paths.